### PR TITLE
style!: eliminar selectores css del layout

### DIFF
--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,6 +1,6 @@
 export default function About() {
   return (
-    <div className="flex flex-col justify-between !p-0">
+    <main className="min-h-screen vstack justify-between">
       <img src="/border.svg" alt="border_top" className="max-h-40 mr-auto" />
       <div className="container px-10 md:px-12 lg:px-14 mx-auto">
         <h2 className="py-4">
@@ -57,6 +57,6 @@ export default function About() {
         alt="border_down"
         className="rotate-180 max-h-40 ml-auto"
       />
-    </div>
+    </main>
   );
 }

--- a/src/app/calendario/page.jsx
+++ b/src/app/calendario/page.jsx
@@ -2,9 +2,9 @@ import { Calendario } from "@/features/calendario";
 
 export default function CalendarioPage() {
   return (
-    <div className="px-6 pb-12 flex flex-col items-center overflow-hidden w-full my-auto">
+    <main className="px-auto flex-col center mb-5">
       <p className="pb-6 text-xl font-semibold">Calendario</p>
       <Calendario />
-    </div>
+    </main>
   );
 }

--- a/src/app/carrito/page.jsx
+++ b/src/app/carrito/page.jsx
@@ -2,8 +2,8 @@ import { Pago } from "@/features/carrito";
 
 export default function CarritoPage() {
   return (
-    <div className="flex flex-col justify-center items-center px-6 pb-12 gap-8 w-full">
+    <main className="px-auto center flex-col">
       <Pago />
-    </div>
+    </main>
   );
 }

--- a/src/app/edit_profile/page.jsx
+++ b/src/app/edit_profile/page.jsx
@@ -1,13 +1,13 @@
 import Form from "@/components/Form/Form";
 const EditProfilePage = () => {
   return (
-    <div className="w-full">
+    <main className="center pt-8 pb-12">
       <div className="flex justify-center items-center h-full">
         <Form />
       </div>
-    </div>
+    </main>
   );
 };
 
 export default EditProfilePage;
- 
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,23 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-input::-ms-reveal,
-input::-ms-clear {
-  display: none;
-}
-
-b {
-  @apply font-bold;
-}
-
-i {
-  @apply italic;
-}
-
-blockquote {
-  @apply pl-4 border-l-2 border-secondary-300 italic;
-}
-
 /* ul { */
 /*   @apply list-disc; */
 /* } */
@@ -31,16 +14,6 @@ blockquote {
 /* ul { */
 /*   @apply px-4; */
 /* } */
-
-@layer components {
-  .debug {
-    @apply border border-red-500;
-  }
-
-  .center {
-    @apply flex justify-center items-center;
-  }
-}
 
 @layer base {
   h1 {
@@ -80,5 +53,22 @@ blockquote {
   ::-webkit-scrollbar-track {
     @apply bg-zinc-300;
     @apply rounded-full;
+  }
+
+  blockquote {
+    @apply pl-4 border-l-2 border-secondary-300 italic;
+  }
+
+  input::-ms-reveal,
+  input::-ms-clear {
+    display: none;
+  }
+
+  b {
+    @apply font-bold;
+  }
+
+  i {
+    @apply italic;
   }
 }

--- a/src/app/loading.jsx
+++ b/src/app/loading.jsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="flex justify-center items-center">
+    <main className="center">
       <div role="status">
         <svg
           aria-hidden="true"
@@ -20,6 +20,6 @@ export default function Loading() {
         </svg>
         <span className="sr-only">Cargando...</span>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -3,9 +3,9 @@ import { Login } from "../../components/Login";
 
 const Page = () => {
   return (
-    <div className="flex justify-center items-center bg-[#68BCE3] w-full static">
+    <main className="px-auto min-h-screen center bg-primary-400">
       <Login />
-    </div>
+    </main>
   );
 };
 export default Page;

--- a/src/app/mis_compras/page.jsx
+++ b/src/app/mis_compras/page.jsx
@@ -26,8 +26,8 @@ function TablaCompras() {
 
 export default function MisComprasPage() {
   return (
-    <div className="p-8 w-full m-auto">
+    <main className="px-auto center mb-5">
       <TablaCompras />
-    </div>
+    </main>
   );
 }

--- a/src/app/mis_mensajes/page.jsx
+++ b/src/app/mis_mensajes/page.jsx
@@ -4,25 +4,27 @@ import { twMerge } from "tailwind-merge";
 
 export default function MisMensajesPage() {
   return (
-    <div className="flex flex-row max-h-[520px] max-w-fit my-auto">
-      <div className="flex flex-col overflow-y-auto gap-2">
-        {Array(10)
-          .fill(0)
-          .map((_, i) => (
-            <div
-              key={i}
-              className={twMerge(
-                "bg-primary-300 px-6 py-2 rounded-lg text-black w-64 mr-4",
-                "flex items-center",
-                2 === i && "bg-primary-800 text-white",
-              )}
-            >
-              <Avatar src="https://i.pravatar.cc/150?u=a042581f4e29026024d" />
-              <p className="text-lg mx-auto">Ronald Marino</p>
-            </div>
-          ))}
+    <main className="center pt-8 pb-12 px-auto">
+      <div className="flex flex-row max-h-[520px] max-w-fit my-auto">
+        <div className="flex flex-col overflow-y-auto gap-2">
+          {Array(10)
+            .fill(0)
+            .map((_, i) => (
+              <div
+                key={i}
+                className={twMerge(
+                  "bg-primary-300 px-6 py-2 rounded-lg text-black w-64 mr-4",
+                  "flex items-center",
+                  2 === i && "bg-primary-800 text-white",
+                )}
+              >
+                <Avatar src="https://i.pravatar.cc/150?u=a042581f4e29026024d" />
+                <p className="text-lg mx-auto">Ronald Marino</p>
+              </div>
+            ))}
+        </div>
+        <Chat />
       </div>
-      <Chat />
-    </div>
+    </main>
   );
 }

--- a/src/app/mis_productos/page.jsx
+++ b/src/app/mis_productos/page.jsx
@@ -26,8 +26,8 @@ function TablaCompras() {
 
 export default function MisComprasPage() {
   return (
-    <div className="p-8 w-full m-auto">
+    <main className="px-auto center pt-8 pb-12">
       <TablaCompras />
-    </div>
+    </main>
   );
 }

--- a/src/app/mis_servicios/page.jsx
+++ b/src/app/mis_servicios/page.jsx
@@ -1,6 +1,9 @@
 import { CustomTable, CustomTableHeader } from "@/features/ui";
-import { RxTrash } from "react-icons/rx";
-import { HiOutlinePencil } from "react-icons/hi2";
+import { RxTrash, RxPencil1 } from "react-icons/rx";
+
+// NOTE: Hero icons broken
+//       https://github.com/react-icons/react-icons/issues/931
+// import { HiOutlinePencil } from "react-icons/hi2";
 
 const items = new Array(20).fill().map((_, index) => ({
   key: index + 1,
@@ -16,7 +19,7 @@ const items = new Array(20).fill().map((_, index) => ({
     "mollit anim id est laborum.",
 }));
 
-function CustomTableBody({}) {
+function CustomTableBody() {
   return (
     <tbody className="whitespace-nowrap text-center">
       {items.map((item) => (
@@ -36,7 +39,7 @@ function CustomTableBody({}) {
           <td className="px-12 py-3">
             <div className="flex flex-row gap-8">
               <RxTrash className="text-primary text-2xl" />
-              <HiOutlinePencil className="text-primary text-2xl" />
+              <RxPencil1 className="text-primary text-2xl" />
             </div>
           </td>
         </tr>
@@ -47,14 +50,14 @@ function CustomTableBody({}) {
 
 function MisServiciosPage() {
   return (
-    <div className="p-6 overflow-hidden m-auto w-full">
+    <main className="px-auto center pt-8 pb-12">
       <CustomTable>
         <CustomTableHeader
           headers={["Servicio", "Descripción", "Precio", ""]}
         />
         <CustomTableBody />
       </CustomTable>
-    </div>
+    </main>
   );
 }
 export default MisServiciosPage;

--- a/src/app/not-found.jsx
+++ b/src/app/not-found.jsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="center flex-col gap-1 min-h-[92vh] text-center w-screen !max-w-[unset]">
+    <main className="relative center flex-col gap-1 min-h-[92vh] text-center w-screen !max-w-[unset]">
       <img
         className="absolute bottom-0 left-0 h-[42%] max-sm:w-1/2 max-sm:h-auto"
         alt="logo_overlay"
@@ -33,6 +33,6 @@ export default function NotFound() {
         </Link>
         .
       </p>
-    </div>
+    </main>
   );
 }

--- a/src/app/overlay.jsx
+++ b/src/app/overlay.jsx
@@ -15,41 +15,13 @@ export function Overlay({ children }) {
   const pathname = usePathname();
 
   if (exclude.includes(pathname)) {
-    return (
-      <main
-        className={[
-          // center
-          "flex justify-center items-center",
-          // container
-          "[&>div]:relative [&>div]:mx-auto",
-          "[&>div]:px-4 [&>div]:md:px-6 [&>div]:lg:px-8",
-          // NOTE: disable max width
-          // "[&>div]:max-w-[90rem]",
-          // extras
-          "min-h-screen",
-          "[&>div]:min-h-screen [&>div]:flex-1 [&>div]:overflow-hidden",
-        ].join(" ")}
-      >
-        {children}
-      </main>
-    );
+    return children;
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen grid grid-rows-[auto_1fr_auto]">
       <Nav />
-      <main
-        className={[
-          // container
-          "[&>div]:relative [&>div]:mx-auto",
-          "[&>div]:px-4 [&>div]:md:px-6 [&>div]:lg:px-8",
-          "[&>div]:max-w-[90rem]",
-          // extras
-          "flex min-h-[92vh] [&>div]:overflow-hidden",
-        ].join(" ")}
-      >
-        {children}
-      </main>
+      {children}
       <Footer />
     </div>
   );

--- a/src/app/pacientes/page.jsx
+++ b/src/app/pacientes/page.jsx
@@ -2,14 +2,9 @@ import { Tabla } from "@/features/pacientes";
 
 export default function PacientesPage() {
   return (
-    <div
-      className={[
-        "flex justify-center flex-col items-center",
-        "px-6 pb-12 overflow-hidden w-full",
-      ].join(" ")}
-    >
+    <main className="center flex-col px-auto">
       <p className="pb-6 text-xl font-semibold">Historia Clinica - Pacientes</p>
       <Tabla />
-    </div>
+    </main>
   );
 }

--- a/src/app/page.client.jsx
+++ b/src/app/page.client.jsx
@@ -126,38 +126,36 @@ export default function HomeClient() {
   );
 
   return (
-    <div className="mb-20 max-w-2xl shadow-xl border-1 rounded-xl bg-white p-3">
-      <Tabs
-        fullWidth
-        color="primary"
-        aria-label="Tabs-form"
-        disableAnimation
-        selectedKey={selected}
-        onSelectionChange={setSelected}
+    <Tabs
+      fullWidth
+      color="primary"
+      aria-label="Tabs-form"
+      disableAnimation
+      selectedKey={selected}
+      onSelectionChange={setSelected}
+    >
+      <Tab
+        key="citaDomiciliaria"
+        title={
+          <div className="flex items-center space-x-2">
+            <BiSolidHome />
+            <span>Cita Domiciliaria</span>
+          </div>
+        }
       >
-        <Tab
-          key="citaDomiciliaria"
-          title={
-            <div className="flex items-center space-x-2">
-              <BiSolidHome />
-              <span>Cita Domiciliaria</span>
-            </div>
-          }
-        >
-          <CitaDomiciliaria />
-        </Tab>
-        <Tab
-          key="citaOnline"
-          title={
-            <div className="flex items-center space-x-2">
-              <BiSolidWebcam />
-              <span>Cita Online</span>
-            </div>
-          }
-        >
-          <CitaOnline />
-        </Tab>
-      </Tabs>
-    </div>
+        <CitaDomiciliaria />
+      </Tab>
+      <Tab
+        key="citaOnline"
+        title={
+          <div className="flex items-center space-x-2">
+            <BiSolidWebcam />
+            <span>Cita Online</span>
+          </div>
+        }
+      >
+        <CitaOnline />
+      </Tab>
+    </Tabs>
   );
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -2,14 +2,15 @@ import HomeClient from "./page.client";
 
 export default function Home() {
   return (
-    <div
+    <main
       className={[
         "bg-[url('/Home.jpg')] bg-no-repeat bg-cover",
-        "w-full !max-w-[unset]",
-        "center [&>div]:grow",
+        "px-auto center min-h-[92vh]",
       ].join(" ")}
     >
-      <HomeClient />
-    </div>
+      <div className="grow bg-white p-3 mb-20 max-w-2xl shadow-xl border-1 rounded-xl">
+        <HomeClient />
+      </div>
+    </main>
   );
 }

--- a/src/app/pregunta_experto/client.jsx
+++ b/src/app/pregunta_experto/client.jsx
@@ -24,7 +24,7 @@ function PreguntaExpertoClient() {
   }, [comments]);
 
   return (
-    <div className="p-4 w-full max-w-4xl flex flex-col items-center mx-auto gap-4">
+    <main className="p-4 w-full max-w-4xl flex flex-col items-center mx-auto gap-4">
       <Question comments={comments} setComments={setComments} />
       {comments.length > 0 && (
         <button
@@ -50,7 +50,7 @@ function PreguntaExpertoClient() {
           ))
         )}
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/src/app/productos/[productoId]/page.client.jsx
+++ b/src/app/productos/[productoId]/page.client.jsx
@@ -29,15 +29,15 @@ const ProductDetailPageClient = ({ productId }) => {
   }, []);
 
   return (
-    <div
+    <main
       className={[
-        "flex flex-col w-full min-h-screen items-center justify-between",
-        "sm:flex-row sm:items-start",
+        "px-auto flex flex-col w-full items-center",
+        "sm:justify-between sm:flex-row sm:items-start",
       ].join(" ")}
     >
       <DetailClient prod={prod} />
       <Aside prod={prod} />
-    </div>
+    </main>
   );
 };
 

--- a/src/app/registro/page.jsx
+++ b/src/app/registro/page.jsx
@@ -2,9 +2,9 @@ import Register from "../../components/Registro/Register";
 
 const RegistroPage = () => {
   return (
-    <div className="flex justify-center items-center bg-[#68BCE3] w-full static">
+    <main className="px-auto min-h-screen center bg-primary-400">
       <Register />
-    </div>
+    </main>
   );
 };
 

--- a/src/app/servicio_profesional/page.jsx
+++ b/src/app/servicio_profesional/page.jsx
@@ -2,8 +2,8 @@ import ServicioProfesionalFormulario from "./ServicioProfesionalFormulario";
 
 export default function ServicioProfesionalPage() {
   return (
-    <div className="p-6 overflow-hidden m-auto w-full">
+    <main className="center pt-8 pb-12">
       <ServicioProfesionalFormulario />
-    </div>
+    </main>
   );
 }

--- a/src/app/servicios_home/page.jsx
+++ b/src/app/servicios_home/page.jsx
@@ -17,7 +17,7 @@ const links = [
 
 export default function ServiciosHomePage() {
   return (
-    <div className="grid md:grid-cols-3 !p-0 grid-rows-3 md:grid-rows-1">
+    <main className="min-h-screen grid md:grid-cols-3 !p-0 grid-rows-3 md:grid-rows-1">
       {links.map((item) => (
         <Link
           key={item.name}
@@ -36,6 +36,6 @@ export default function ServiciosHomePage() {
           </div>
         </Link>
       ))}
-    </div>
+    </main>
   );
 }

--- a/src/app/trabajaConNosotros/client.jsx
+++ b/src/app/trabajaConNosotros/client.jsx
@@ -52,7 +52,7 @@ const TrabajaConNosotrosClient = () => {
   };
 
   return (
-    <div className="p-14 justify-center w-full">
+    <main className="max-w-8xl mx-auto p-14 w-full">
       <div className="flex items-center gap-10">
         <img width="40" src="/logo_simple.webp" alt="logo" />
         <p>
@@ -253,7 +253,7 @@ const TrabajaConNosotrosClient = () => {
           )}
         </div>
       </form>
-    </div>
+    </main>
   );
 };
 

--- a/src/app/tratamientos/page.jsx
+++ b/src/app/tratamientos/page.jsx
@@ -3,9 +3,9 @@ import data from "@/components/Tratamientos/data/treatmentsList.json";
 
 const TreatmentsPage = () => {
   return (
-    <div className="container mx-auto w-fit p-4 pb-4">
+    <main className="maw-w-8xl center px-auto pt-16 pb-28">
       <TreatmentCardContainer treats={data.treatments} />
-    </div>
+    </main>
   );
 };
 

--- a/src/components/Blog/BlogCards.jsx
+++ b/src/components/Blog/BlogCards.jsx
@@ -1,7 +1,7 @@
-import { useRouter } from 'next/navigation';
-import { Pagination, Card, CardHeader, Image } from '@nextui-org/react';
-import { getBlogs } from '@/services/blogs';
-import { stripHTMLTags } from '@/utils/helpers';
+import { useRouter } from "next/navigation";
+import { Pagination, Card, CardHeader, Image } from "@nextui-org/react";
+import { getBlogs } from "@/services/blogs";
+import { stripHTMLTags } from "@/utils/helpers";
 
 export default function BlogCards({
   blogs,

--- a/src/components/Blog/BlogSection.jsx
+++ b/src/components/Blog/BlogSection.jsx
@@ -1,7 +1,7 @@
-'use client';
-import { useState } from 'react';
-import BlogCards from './BlogCards';
-import BlogAside from './BlogAside';
+"use client";
+import { useState } from "react";
+import BlogCards from "./BlogCards";
+import BlogAside from "./BlogAside";
 
 const CARDS_PER_PAGE = 9;
 
@@ -12,12 +12,18 @@ const BlogSection = ({ data, lastsBlogs }) => {
   const [totalPages, setTotalPages] = useState(data.totalPages);
   const [query, setQuery] = useState({
     limit: CARDS_PER_PAGE,
-    sortBy: 'title',
-    order: 'asc',
+    sortBy: "title",
+    order: "asc",
   });
 
   return (
-    <div className="w-full grid gap-y-7 gap-x-10 py-4 md:py-6 xl:grid-cols-[auto,30%]">
+    <main
+      className={[
+        "max-w-8xl mx-auto px-auto",
+        "grid gap-y-7 gap-x-10",
+        "py-4 md:py-6 xl:grid-cols-[auto,30%]",
+      ].join(" ")}
+    >
       <BlogCards
         blogs={blogs}
         page={page}
@@ -33,7 +39,7 @@ const BlogSection = ({ data, lastsBlogs }) => {
         setTotalPages={setTotalPages}
         setQuery={setQuery}
       />
-    </div>
+    </main>
   );
 };
 

--- a/src/components/Comunidad/ComunidadClient.jsx
+++ b/src/components/Comunidad/ComunidadClient.jsx
@@ -5,10 +5,10 @@ import SearchUsers from "./SearchUser";
 import UsersContainer from "./UsersContainer";
 import dynamic from "next/dynamic";
 
-const Map = dynamic(()=> import ("@/components/Map"), {
+const Map = dynamic(() => import("@/components/Map"), {
   loading: () => <p>loading...</p>,
-  ssr: false
-})
+  ssr: false,
+});
 
 const ComunidadClient = ({ users }) => {
   const [usersFiltered, setUsersFiltered] = useState([...users]);
@@ -20,8 +20,8 @@ const ComunidadClient = ({ users }) => {
   ];
 
   return (
-    <div className="w-full min-h-screen mb-10 flex flex-row gap-5 pt-6 md:pr-5 md:pl-5">
-      <div className="w-full flex flex-col items-center gap-10 md:w-1/2 md:max-h-screen">
+    <main className="max-w-8xl mx-auto w-full mb-10 hstack gap-5 px-auto">
+      <div className="w-full flex flex-col items-center gap-10 md:w-1/2">
         <SearchUsers
           usersFiltered={usersFiltered}
           setUsersFiltered={setUsersFiltered}
@@ -29,10 +29,10 @@ const ComunidadClient = ({ users }) => {
         />
         <UsersContainer users={usersFiltered} />
       </div>
-      <div className="hidden md:w-1/2 md:flex h-screen">
+      <div className="hidden md:w-1/2 md:flex">
         <Map markers={markers} />
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/src/components/Recupero/Recupero.jsx
+++ b/src/components/Recupero/Recupero.jsx
@@ -8,7 +8,7 @@ const Recupero = () => {
   const [email, setEmail] = useState("");
 
   return (
-    <div className="center bg-primary-400">
+    <main className="px-auto min-h-screen center bg-primary-400">
       <img
         className="absolute bottom-0 left-0 h-1/2 max-sm:w-2/3 max-sm:h-auto"
         alt="logo_overlay"
@@ -42,7 +42,7 @@ const Recupero = () => {
           </Link>
         </div>
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/src/components/Servicios/ServicioMain.jsx
+++ b/src/components/Servicios/ServicioMain.jsx
@@ -46,7 +46,7 @@ const ServicioMain = ({ data }) => {
   }, [filters]);
 
   return (
-    <div className="flex flex-col w-full m-4">
+    <main className="vstack px-auto mx-auto max-w-8xl w-full">
       <SearchProfesional filters={filters} setFilters={setFilters} />
       <div className="flex w-full min-h-min">
         <ServicioMainContainer profesionales={professionals} />
@@ -54,7 +54,7 @@ const ServicioMain = ({ data }) => {
           <Map markers={markers} />
         </div>
       </div>
-    </div>
+    </main>
   );
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 import { nextui } from "@nextui-org/react";
+import plugin from "tailwindcss/plugin";
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -6,6 +7,45 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx,html}",
     "./node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}",
   ],
+  plugins: [
+    plugin(function ({ addComponents, addUtilities, theme }) {
+      addComponents({
+        ".hstack": {
+          display: "flex",
+          flexDirection: "row",
+        },
+        ".vstack": {
+          display: "flex",
+          flexDirection: "column",
+        },
+        ".debug": {
+          border: "1px solid",
+          borderColor: theme("colors.red.500"),
+        },
+        ".center": {
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        },
+      });
+      addUtilities({
+        ".px-auto": {
+          "@apply px-4 md:px-6 lg:px-8": {},
+        },
+      });
+    }),
+    nextui({
+      themes: {
+        light: {
+          colors: {
+            background: "#FFFFFF",
+            foreground: "#000000",
+          },
+        },
+      },
+    }),
+  ],
+  darkMode: "class",
   theme: {
     extend: {
       maxWidth: {
@@ -93,17 +133,4 @@ module.exports = {
       },
     },
   },
-  darkMode: "class",
-  plugins: [
-    nextui({
-      themes: {
-        light: {
-          colors: {
-            background: "#FAFAFA",
-            foreground: "#0D0D0D",
-          },
-        },
-      },
-    }),
-  ],
 };


### PR DESCRIPTION
- Se eliminaron los selectores css del layout.
- Se agregaron las siguientes clases a tailwind: `hstack`, `vstack`, `debug`, `center`, `px-auto`, `max-w-8xl`.